### PR TITLE
fix compatibility with newer versions of Go

### DIFF
--- a/russiantime.go
+++ b/russiantime.go
@@ -1,8 +1,8 @@
 package russiantime
 
 import (
-	. "math/big"
-	. "strconv"
+	"math/big"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -10,13 +10,13 @@ import (
 //Struct contains embedded time.Time
 type Time struct {
 	time.Time
-	year                                       *Int
+	year                                       *big.Int
 	month, day, weekday, hour, minute, seconds int
 }
 
 //Format time to russian
 func (t *Time) FormatRU(layout string) (rustime string) {
-	t.year = NewInt(int64(t.Year()))
+	t.year = big.NewInt(int64(t.Year()))
 	t.month = int(t.Month())
 	t.day = int(t.Day())
 	t.weekday = int(t.Weekday())
@@ -28,26 +28,26 @@ func (t *Time) FormatRU(layout string) (rustime string) {
 		rustime = strings.Replace(rustime, "%YYYY", strings.Repeat("0", 4-len(t.year.String()))+t.year.String(), -1)
 	}
 	if strings.Contains(rustime, "%YYY") {
-		var years Int
-		years.Mod(t.year, NewInt(1000))
+		var years big.Int
+		years.Mod(t.year, big.NewInt(1000))
 		rustime = strings.Replace(rustime, "%YYY", strings.Repeat("0", 3-len(years.String()))+years.String(), -1)
 	}
 	if strings.Contains(rustime, "%YY") {
-		var years Int
-		years.Mod(t.year, NewInt(100))
+		var years big.Int
+		years.Mod(t.year, big.NewInt(100))
 		rustime = strings.Replace(rustime, "%YY", strings.Repeat("0", 2-len(years.String()))+years.String(), -1)
 	}
 	if strings.Contains(rustime, "%Y") {
-		var years Int
-		years.Mod(t.year, NewInt(10))
+		var years big.Int
+		years.Mod(t.year, big.NewInt(10))
 		rustime = strings.Replace(rustime, "%Y", strings.Repeat("0", 1-len(years.String()))+years.String(), -1)
 	}
 	//Parse month
 	if strings.Contains(rustime, "%md") {
-		rustime = strings.Replace(rustime, "%md", Itoa(int(t.month)), -1)
+		rustime = strings.Replace(rustime, "%md", strconv.Itoa(int(t.month)), -1)
 	}
 	if strings.Contains(rustime, "%Md") {
-		rustime = strings.Replace(rustime, "%Md", strings.Repeat("0", 2-len(Itoa(int(t.month))))+Itoa(int(t.month)), -1)
+		rustime = strings.Replace(rustime, "%Md", strings.Repeat("0", 2-len(strconv.Itoa(int(t.month))))+strconv.Itoa(int(t.month)), -1)
 	}
 	if strings.Contains(rustime, "%m") {
 		rustime = strings.Replace(rustime, "%m", shortMonthNames[t.month], -1)
@@ -57,14 +57,14 @@ func (t *Time) FormatRU(layout string) (rustime string) {
 	}
 	//Parse Day
 	if strings.Contains(rustime, "%D") {
-		rustime = strings.Replace(rustime, "%D", strings.Repeat("0", 2-len(Itoa(t.day)))+Itoa(t.day), -1)
+		rustime = strings.Replace(rustime, "%D", strings.Repeat("0", 2-len(strconv.Itoa(t.day)))+strconv.Itoa(t.day), -1)
 	}
 	if strings.Contains(rustime, "%d") {
-		rustime = strings.Replace(rustime, "%d", Itoa(t.day), -1)
+		rustime = strings.Replace(rustime, "%d", strconv.Itoa(t.day), -1)
 	}
 	//Parse week day
 	if strings.Contains(rustime, "%Wd") {
-		rustime = strings.Replace(rustime, "%Wd", Itoa(int(t.weekday)), -1)
+		rustime = strings.Replace(rustime, "%Wd", strconv.Itoa(int(t.weekday)), -1)
 	}
 	if strings.Contains(rustime, "%w") {
 		rustime = strings.Replace(rustime, "%w", shortDayNames[t.weekday], -1)
@@ -74,24 +74,24 @@ func (t *Time) FormatRU(layout string) (rustime string) {
 	}
 	//Parse hour
 	if strings.Contains(rustime, "%H") {
-		rustime = strings.Replace(rustime, "%H", strings.Repeat("0", 2-len(Itoa(t.hour)))+Itoa(t.hour), -1)
+		rustime = strings.Replace(rustime, "%H", strings.Repeat("0", 2-len(strconv.Itoa(t.hour)))+strconv.Itoa(t.hour), -1)
 	}
 	if strings.Contains(rustime, "%h") {
-		rustime = strings.Replace(rustime, "%h", Itoa(t.hour), -1)
+		rustime = strings.Replace(rustime, "%h", strconv.Itoa(t.hour), -1)
 	}
 	//Parse minute
 	if strings.Contains(rustime, "%N") {
-		rustime = strings.Replace(rustime, "%N", strings.Repeat("0", 2-len(Itoa(t.minute)))+Itoa(t.minute), -1)
+		rustime = strings.Replace(rustime, "%N", strings.Repeat("0", 2-len(strconv.Itoa(t.minute)))+strconv.Itoa(t.minute), -1)
 	}
 	if strings.Contains(rustime, "%n") {
-		rustime = strings.Replace(rustime, "%n", Itoa(t.minute), -1)
+		rustime = strings.Replace(rustime, "%n", strconv.Itoa(t.minute), -1)
 	}
 	//Parse second
 	if strings.Contains(rustime, "%S") {
-		rustime = strings.Replace(rustime, "%S", strings.Repeat("0", 2-len(Itoa(t.seconds)))+Itoa(t.seconds), -1)
+		rustime = strings.Replace(rustime, "%S", strings.Repeat("0", 2-len(strconv.Itoa(t.seconds)))+strconv.Itoa(t.seconds), -1)
 	}
 	if strings.Contains(rustime, "%s") {
-		rustime = strings.Replace(rustime, "%s", Itoa(t.seconds), -1)
+		rustime = strings.Replace(rustime, "%s", strconv.Itoa(t.seconds), -1)
 	}
 	return rustime
 }


### PR DESCRIPTION
Importing both "math/big" and "strconv" exported identifiers into file block
creates conflict with current versions of Go:

  ParseFloat redeclared during import "strconv"at line 5 col 1 previous
  declaration during import "math/big" (build)

Solve it using qualified identifiers.

See http://ru.stackoverflow.com/questions/521829/ also.
